### PR TITLE
Add parameters to customize the output of a Logger.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/mborders/logmatic
 
+go 1.15
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.7.0

--- a/logger.go
+++ b/logger.go
@@ -3,6 +3,7 @@ package logmatic
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -11,32 +12,132 @@ import (
 var printf = fmt.Printf
 var exit = os.Exit
 
+// default colors for various log levels
+const (
+	defaultTraceColor = color.FgBlue
+	defaultDebugColor = color.FgGreen
+	defaultInfoColor  = color.FgCyan
+	defaultWarnColor  = color.FgYellow
+	defaultErrorColor = color.FgRed
+)
+
 // logFunc represents a log function
 type logFunc func(a ...interface{}) string
 
 // Logger maintains a set of logging functions
 // and has a log level that can be modified dynamically
 type Logger struct {
-	level       LogLevel
-	trace       logFunc
-	debug       logFunc
-	info        logFunc
-	warn        logFunc
-	error       logFunc
-	fatal       logFunc
-	ExitOnFatal bool
+	level             LogLevel
+	trace             logFunc
+	debug             logFunc
+	info              logFunc
+	warn              logFunc
+	error             logFunc
+	fatal             logFunc
+	ExitOnFatal       bool   // If true, logger will run os.Exit(1) when calling Fatal().
+	ShowTimestamp     bool   // If true, logger will show the current timestamp in its output. Default: true
+	UseUnixTimestamp  bool   // If true and ShowTimestamp is true, logger will print the current timestamp as a unix timestamp instead of a UTC string. Default: false
+	UnixTimestampNano bool   // If true and UseUnixTimestamp is true, logger will print the current timestamp as nanoseconds instead of seconds. Default: false
+	Separator         string // Separator string to use between log level output and log message output. Default: "=>"
+	ShowSeparator     bool   // Controls whether Separator is shown when logging. Default: true
+	ColorizeMessages  bool   // Controls whether log messages are shown with the same color (unbolded) as their log level. Default: false
 }
 
 func (l *Logger) now() string {
-	return time.Now().Format("2006-01-02 15:04:05")
+	now := time.Now()
+
+	if l.UseUnixTimestamp {
+		var timestamp int64
+
+		switch l.UnixTimestampNano {
+		case true:
+			timestamp = now.UnixNano()
+		default:
+			timestamp = now.Unix()
+		}
+		return fmt.Sprintf("%[1]d", timestamp)
+	}
+
+	return now.Format(defaultTimeformat)
+}
+
+// builds a format string using the logger's parameter fields
+func (l *Logger) buildFormatString() string {
+	var sb strings.Builder
+
+	// add format placeholder for the current timestamp, if applicable
+	if l.ShowTimestamp {
+		switch l.UseUnixTimestamp {
+		case true:
+			sb.WriteString("%d")
+		default:
+			sb.WriteString("%s")
+		}
+	}
+
+	// add format placeholder for log level
+	sb.WriteString("%s")
+
+	// add format placeholder for separator, if applicable
+	if l.ShowSeparator {
+		sb.WriteString("%s")
+	}
+
+	// add format placeholder for the actual data
+	sb.WriteString("%s")
+
+	sb.WriteString("\n")
+
+	return sb.String()
+}
+
+func (l *Logger) buildLogArgs(level, format string, a ...interface{}) []interface{} {
+	var logArgs []interface{}
+
+	if l.ShowTimestamp {
+		logArgs = append(logArgs, color.MagentaString(l.now()))
+	}
+
+	logArgs = append(logArgs, level)
+
+	if l.ShowSeparator {
+		logArgs = append(logArgs, color.MagentaString(l.Separator))
+	}
+
+	msgStr := fmt.Sprintf(format, a...)
+	if l.ColorizeMessages {
+		var sprintFunc logFunc
+
+		switch level {
+		case "TRACE":
+			sprintFunc = l.trace
+		case "DEBUG":
+			sprintFunc = l.debug
+		case "INFO":
+			sprintFunc = l.info
+		case "WARN":
+			sprintFunc = l.warn
+		case "ERROR":
+			sprintFunc = l.error
+		case "FATAL":
+			sprintFunc = l.fatal
+		default:
+			sprintFunc = l.debug
+		}
+
+		msgStr = sprintFunc(msgStr)
+	}
+
+	logArgs = append(logArgs, msgStr)
+
+	return logArgs
 }
 
 func (l *Logger) log(level string, format string, a ...interface{}) {
-	printf("%s %s %s %s\n",
-		color.MagentaString(l.now()),
-		level,
-		color.MagentaString("=>"),
-		fmt.Sprintf(format, a...))
+	formatString := l.buildFormatString()
+	logArgs := l.buildLogArgs(level, format, a...)
+
+	printf(formatString, logArgs...)
 }
 
 // SetLevel updates the logging level for future logs
@@ -94,17 +195,27 @@ func (l *Logger) Fatal(format string, a ...interface{}) {
 	}
 }
 
-// NewLogger creates a new logger
-// Default level is INFO
-func NewLogger() *Logger {
+// NewLogger creates a new logger using provided params (or default values).
+// Default log level is INFO
+func NewLogger(params *LoggerParams) *Logger {
+	if params == nil {
+		params = NewLoggerParams()
+	}
+
 	return &Logger{
-		level:       INFO,
-		trace:       color.New(color.FgBlue).SprintFunc(),
-		debug:       color.New(color.FgGreen).SprintFunc(),
-		info:        color.New(color.FgCyan).SprintFunc(),
-		warn:        color.New(color.FgYellow).SprintFunc(),
-		error:       color.New(color.FgRed).SprintFunc(),
-		fatal:       color.New(color.FgRed, color.Bold).SprintFunc(),
-		ExitOnFatal: true,
+		level:             params.LogLevel(),
+		trace:             color.New(defaultTraceColor).SprintFunc(),
+		debug:             color.New(defaultDebugColor).SprintFunc(),
+		info:              color.New(defaultInfoColor).SprintFunc(),
+		warn:              color.New(defaultWarnColor).SprintFunc(),
+		error:             color.New(defaultErrorColor).SprintFunc(),
+		fatal:             color.New(defaultErrorColor, color.Bold).SprintFunc(),
+		ExitOnFatal:       params.ExitOnFatal(),
+		ShowTimestamp:     params.ShowTimestamp(),
+		UseUnixTimestamp:  params.UseUnixTimestamp(),
+		UnixTimestampNano: params.UnixTimestampNano(),
+		Separator:         params.Separator(),
+		ShowSeparator:     params.ShowSeparator(),
+		ColorizeMessages:  params.ColorizeMessages(),
 	}
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 )
 
+var testParams = NewLoggerParams()
+
 func mockPrint(buf *bytes.Buffer) {
 	printf = func(format string, a ...interface{}) (int, error) {
 		buf.WriteString(fmt.Sprintf(format, a...))
@@ -18,7 +20,7 @@ func TestLogger_Trace_Print(t *testing.T) {
 	var buf bytes.Buffer
 	mockPrint(&buf)
 
-	l := NewLogger()
+	l := NewLogger(testParams)
 	l.SetLevel(TRACE)
 	l.Trace("Trace")
 	assert.NotEmpty(t, buf)
@@ -28,7 +30,7 @@ func TestLogger_Trace_NoPrint(t *testing.T) {
 	var buf bytes.Buffer
 	mockPrint(&buf)
 
-	l := NewLogger()
+	l := NewLogger(testParams)
 	l.Trace("Trace")
 	assert.Empty(t, buf)
 }
@@ -37,7 +39,7 @@ func TestLogger_Debug_Print(t *testing.T) {
 	var buf bytes.Buffer
 	mockPrint(&buf)
 
-	l := NewLogger()
+	l := NewLogger(testParams)
 	l.SetLevel(DEBUG)
 	l.Debug("Debug")
 	assert.NotEmpty(t, buf)
@@ -47,7 +49,7 @@ func TestLogger_Debug_NoPrint(t *testing.T) {
 	var buf bytes.Buffer
 	mockPrint(&buf)
 
-	l := NewLogger()
+	l := NewLogger(testParams)
 	l.Debug("Debug")
 	assert.Empty(t, buf)
 }
@@ -56,7 +58,7 @@ func TestLogger_Info_Print(t *testing.T) {
 	var buf bytes.Buffer
 	mockPrint(&buf)
 
-	l := NewLogger()
+	l := NewLogger(testParams)
 	l.Info("Info")
 	assert.NotEmpty(t, buf)
 }
@@ -65,7 +67,7 @@ func TestLogger_Info_NoPrint(t *testing.T) {
 	var buf bytes.Buffer
 	mockPrint(&buf)
 
-	l := NewLogger()
+	l := NewLogger(testParams)
 	l.SetLevel(WARN)
 	l.Info("Info")
 	assert.Empty(t, buf)
@@ -75,7 +77,7 @@ func TestLogger_Warn_Print(t *testing.T) {
 	var buf bytes.Buffer
 	mockPrint(&buf)
 
-	l := NewLogger()
+	l := NewLogger(testParams)
 	l.Warn("Warn")
 	assert.NotEmpty(t, buf)
 }
@@ -84,7 +86,7 @@ func TestLogger_Warn_NoPrint(t *testing.T) {
 	var buf bytes.Buffer
 	mockPrint(&buf)
 
-	l := NewLogger()
+	l := NewLogger(testParams)
 	l.SetLevel(ERROR)
 	l.Warn("Warn")
 	assert.Empty(t, buf)
@@ -94,7 +96,7 @@ func TestLogger_Error_Print(t *testing.T) {
 	var buf bytes.Buffer
 	mockPrint(&buf)
 
-	l := NewLogger()
+	l := NewLogger(testParams)
 	l.Error("Error")
 	assert.NotEmpty(t, buf)
 }
@@ -103,7 +105,7 @@ func TestLogger_Error_NoPrint(t *testing.T) {
 	var buf bytes.Buffer
 	mockPrint(&buf)
 
-	l := NewLogger()
+	l := NewLogger(testParams)
 	l.SetLevel(FATAL)
 	l.Error("Error")
 	assert.Empty(t, buf)
@@ -114,7 +116,7 @@ func TestLogger_Fatal_Print(t *testing.T) {
 	mockPrint(&buf)
 	exit = func(code int) {}
 
-	l := NewLogger()
+	l := NewLogger(testParams)
 	l.Fatal("Fatal")
 	assert.NotEmpty(t, buf)
 }

--- a/params.go
+++ b/params.go
@@ -1,0 +1,143 @@
+package logmatic
+
+const (
+	defaultSeparator         = "=>"
+	defaultShowSeparator     = true
+	defaultExitOnFatal       = true
+	defaultShowTimestamp     = true
+	defaultUseUnixTimestamp  = false
+	defaultUnixTimestampNano = false
+	defaultColorizeMessages  = false
+	defaultLogLevel          = INFO
+	defaultTimeformat        = "2006-01-02 15:04:05"
+)
+
+type LoggerParams struct {
+	exitOnFatal       *bool
+	showTimestamp     *bool
+	useUnixTimestamp  *bool
+	unixTimestampNano *bool
+	separator         *string
+	showSeparator     *bool
+	colorizeMessages  *bool
+	logLevel          *LogLevel
+}
+
+type loggerColorParams struct {
+}
+
+func NewLoggerParams() *LoggerParams {
+	return &LoggerParams{}
+}
+
+func (p *LoggerParams) LogLevel() LogLevel {
+	if p.logLevel != nil {
+		return *p.logLevel
+	}
+
+	return defaultLogLevel
+}
+
+func (p *LoggerParams) SetLogLevel(logLevel LogLevel) *LoggerParams {
+	p.logLevel = &logLevel
+
+	return p
+}
+
+func (p *LoggerParams) ExitOnFatal() bool {
+	if p.exitOnFatal != nil {
+		return *p.exitOnFatal
+	}
+
+	return defaultExitOnFatal
+}
+
+func (p *LoggerParams) SetExitOnFatal(exitOnFatal bool) *LoggerParams {
+	p.exitOnFatal = &exitOnFatal
+
+	return p
+}
+
+func (p *LoggerParams) ShowTimestamp() bool {
+	if p.showTimestamp != nil {
+		return *p.showTimestamp
+	}
+
+	return defaultShowTimestamp
+}
+
+func (p *LoggerParams) SetShowTimestamp(showTimestamp bool) *LoggerParams {
+	p.showTimestamp = &showTimestamp
+
+	return p
+}
+
+func (p *LoggerParams) Separator() string {
+	if p.separator != nil {
+		return *p.separator
+	}
+
+	return defaultSeparator
+}
+
+func (p *LoggerParams) SetSeparator(separator string) *LoggerParams {
+	p.separator = &separator
+
+	return p
+}
+
+func (p *LoggerParams) ShowSeparator() bool {
+	if p.showSeparator != nil {
+		return *p.showSeparator
+	}
+
+	return defaultShowSeparator
+}
+
+func (p *LoggerParams) SetShowSeparator(showSeparator bool) *LoggerParams {
+	p.showSeparator = &showSeparator
+
+	return p
+}
+
+func (p *LoggerParams) UseUnixTimestamp() bool {
+	if p.useUnixTimestamp != nil {
+		return *p.useUnixTimestamp
+	}
+
+	return defaultUseUnixTimestamp
+}
+
+func (p *LoggerParams) SetUseUnixTimestamp(useUnixTimestamp bool) *LoggerParams {
+	p.useUnixTimestamp = &useUnixTimestamp
+
+	return p
+}
+
+func (p *LoggerParams) UnixTimestampNano() bool {
+	if p.unixTimestampNano != nil {
+		return *p.unixTimestampNano
+	}
+
+	return defaultUnixTimestampNano
+}
+
+func (p *LoggerParams) SetUnixTimestampNano(unixTimestampNano bool) *LoggerParams {
+	p.unixTimestampNano = &unixTimestampNano
+
+	return p
+}
+
+func (p *LoggerParams) ColorizeMessages() bool {
+	if p.colorizeMessages != nil {
+		return *p.colorizeMessages
+	}
+
+	return defaultColorizeMessages
+}
+
+func (p *LoggerParams) SetColorizeMessages(colorizeMessages bool) *LoggerParams {
+	p.colorizeMessages = &colorizeMessages
+
+	return p
+}


### PR DESCRIPTION
These parameters allow for customizing the output of the logger, such as:

- Showing the timestamp of the log message at all
- Showing a unix timestamp (in seconds or nanoseconds) instead of a stringified timestamp
- Showing a separator between the log level and message
- Customizing the separator between the log level and message
- Colorizing the log message based on its log level. 